### PR TITLE
fix README hightlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # harvard-food-trucks-cli
 
-```shell
+```
 $ npm i -g harvard-food-trucks-cli
 $ harvard-food-trucks
 Thursday, July 14th


### PR DESCRIPTION
The `shell` syntax highlighting was actually doing anything useful for the shell inputs in the README, and had the unfortunate side effect of improperly highlighting parts of the sample output. I thought it looked yucky. Now, it's at least a bit easier on the eyes.

If, in the future, you want to bring back `shell` highlighting you can maybe split up the commands and output.
